### PR TITLE
Fix the issue of nav buttons blocking file explorer content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/theme.css
+++ b/theme.css
@@ -178,18 +178,19 @@ body {
 
 /* ------- new page and new folder buttons ----- */
 
-/* move buttons container to botton */
+/* move buttons container to bottom */
+.workspace-leaf-content[data-type='file-explorer'] {
+  flex-direction: column-reverse;
+}
+
+/* remove redundant spaces */
+div.nav-header {
+  padding: 0px;
+}
+
 .workspace-leaf-content[data-type="file-explorer"] .nav-buttons-container {
-  position: absolute;
-  justify-content: left;
-  bottom: 0;
-  z-index: 1;
-  background-color: var(--background-secondary) !important;
- width: 100%;
- left: 0;
- padding: 0px;
- gap: 0px;
- border-top: var(--divider-width) var(--background-modifier-border) solid;
+  flex-flow: row; /* let the items spread horizontally */
+  border-top: var(--divider-width) var(--background-modifier-border) solid;
 }
 
 /* -- new note -- */


### PR DESCRIPTION
- Add .gitignore file with .DS_Store
- Improve nav buttons styling

**Before** (can't see the "zplaceholder2.md" file)
<img width="355" alt="Screen Shot 2023-03-26 at 14 16 43" src="https://user-images.githubusercontent.com/11176415/227805069-9d68d6fc-be07-4153-8216-6bf2bb0d6f0e.png">

**After**
<img width="339" alt="Screen Shot 2023-03-26 at 14 17 11" src="https://user-images.githubusercontent.com/11176415/227805090-c45ac75e-2bc2-4e6e-8057-8bff550cc183.png">