### PR TITLE
Improve settings page layout and fix duplicate border on community plugins page

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1226,13 +1226,27 @@ body {
 .modal {
   border: none;
 }
+
+.mod-settings div.vertical-tab-content{
+  padding: 36px 60px; /* setting content in notion has padding of 36px 60px */
+}
+.mod-settings div.setting-item {
+  padding: 0px; /* remove original paddings */
+  padding-bottom: 18px; /* setting items in notion have space of 18px */
+}
+
 .setting-item.setting-item-heading {
 border-bottom: 1px solid var(--background-modifier-border);
 margin-bottom: 16px;
-padding-bottom: 12px;
+padding-bottom: 12px !important;
 font-size: var(--font-ui-large);
 font-weight: 500 !important;
 width: auto;
+}
+
+div.installed-plugins-container {
+  border-top: none; /* remove duplicate border on community plugins page */
+  padding-top: 0px; /* remove duplicate 16px padding in community plugins page */
 }
 
 /* ------------- banners --------------- */


### PR DESCRIPTION
**Expectations**
Notion's settings page have the following layouts:
1. The settings content container has padding `36px 60px`
<img width="1012" alt="Screen Shot 2023-03-28 at 17 09 24" src="https://user-images.githubusercontent.com/11176415/228395647-011ab48b-d74f-48eb-9eac-3afa43e5e911.png">

2. The setting items have space of `18px` in between.
<img width="676" alt="Screen Shot 2023-03-28 at 17 10 53" src="https://user-images.githubusercontent.com/11176415/228395712-b6e1d4f7-ee6c-4e11-8039-cf1339f3d5f9.png">

3. The setting headers have bottom padding `12px` and bottom margin `16px`, but no top padding/margins. However, there are blank div blocks before them to create a space of `48px` between the last item of previous section and the header of next section.
<img width="543" alt="Screen Shot 2023-03-28 at 17 28 13" src="https://user-images.githubusercontent.com/11176415/228396015-76d87e9f-00f6-435e-bb1c-ce0be8c4c06d.png">

4. There is no space between the header and the first item of a settings section.
<img width="537" alt="Screen Shot 2023-03-28 at 17 29 54" src="https://user-images.githubusercontent.com/11176415/228396204-0a83e4dc-8ac1-48b6-883f-8567b0f45424.png">
<img width="533" alt="Screen Shot 2023-03-28 at 17 29 57" src="https://user-images.githubusercontent.com/11176415/228396227-ce2c3ccc-28de-4766-bdc0-6f683e3df3d2.png">

**Implementations**
1. Trivial, done
2 & 4. I removed all original paddings of settings items, and have the bottom paddings as `18px`
3. The `48px` block cannot be implemented without knowing whether the header is at the top of the settings page (which does not need such space) or in the middle. Therefore, we shall ignore it for now.

**Fix**
The duplicate issue [here](https://github.com/Bluemoondragon07/obsidian-notation-2/issues/3#issue-1640721912)
